### PR TITLE
Separation of Friend List from Chat

### DIFF
--- a/lib/chat.dart
+++ b/lib/chat.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:text_messenger/text_widgets.dart';
+
+import 'data.dart';
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key, required this.friend});
+
+  final Friend? friend;
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  late TextEditingController _sendController;
+
+  void initState() {
+    super.initState();
+    _sendController = TextEditingController();
+    widget.friend!.addListener(update);
+  }
+
+  void dispose() {
+    widget.friend!.removeListener(update);
+    print("Goodbye");
+    super.dispose();
+  }
+
+  void update() {
+    print("New message!");
+    setState(() {});
+  }
+
+  Future<void> send(String msg) async {
+    await widget.friend!.send(msg).then((value) {
+      setState(() {
+        _sendController.text = "";
+      });
+    }).catchError((e) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text("Error: $e"),
+      ));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String currentFriend = widget.friend!.name;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Chat with " + widget.friend!.name),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          ScrollText(text: widget.friend!.history()),
+          ActionText(
+              width: 200,
+              label: "Send to $currentFriend",
+              inType: TextInputType.text,
+              controller: _sendController,
+              handler: send),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -41,16 +41,12 @@ class _ChatScreenState extends State<ChatScreen> {
   }
 
   Future<void> send(String msg) async {
-    String response = await _sendToCurrentFriend(msg);
-    setState(() {
-      _sendController.text = response;
-    });
-  }
-
-  Future<String> _sendToCurrentFriend(String msg) async {
-    return widget.friend!
-        .send(msg)
-        .then((value) => "")
+    await widget.friend!.send(msg).then((value) {
+      setState(() {
+        _sendController.text = "";
+      });
+    })
+        // TODO FIX WITH SNACKBAR
         .catchError((e) => "Error: $e");
   }
 }

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -49,9 +49,9 @@ class _ChatScreenState extends State<ChatScreen> {
       setState(() {
         _sendController.text = "";
       });
-    })
-        // TODO FIX WITH SNACKBAR
-        .catchError((e) => "Error: $e");
+    });
+    // TODO FIX WITH SNACKBAR
+    //.catchError((e) => "Error: $e");
   }
 }
 
@@ -65,25 +65,9 @@ class Friends extends Iterable<String> {
     _ips2Friends[ip] = f;
   }
 
-  String? getName(String? ipAddr) => _ips2Friends[ipAddr]?.name;
-
   String? ipAddr(String? name) => _names2Friends[name]?.ipAddr;
 
-  bool hasFriend(String? name) => _names2Friends.containsKey(name);
-
   Friend? getFriend(String? name) => _names2Friends[name];
-
-  String historyFor(String? name) {
-    if (hasFriend(name)) {
-      return _names2Friends[name]!.history();
-    } else {
-      return "None";
-    }
-  }
-
-  Future<void> sendTo(String? name, String message) async {
-    return _names2Friends[name]?.send(message);
-  }
 
   void receiveFrom(String ip, String message) {
     print("receiveFrom($ip, $message)");

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -1,8 +1,59 @@
 import 'dart:io';
 import 'package:mutex/mutex.dart';
+import 'package:flutter/material.dart';
+import 'package:text_messenger/text_widgets.dart';
 
 const int ourPort = 8888;
 final m = Mutex();
+
+class ChatScreen extends StatefulWidget {
+  const ChatScreen({super.key, required this.friend});
+
+  final Friend? friend;
+
+  @override
+  State<ChatScreen> createState() => _ChatScreenState();
+}
+
+class _ChatScreenState extends State<ChatScreen> {
+  late TextEditingController _sendController;
+
+  void initState() {
+    super.initState();
+    _sendController = TextEditingController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String currentFriend = widget.friend!.name;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        ScrollText(text: widget.friend!.history()),
+        ActionText(
+            width: 200,
+            label: "Send to $currentFriend",
+            inType: TextInputType.text,
+            controller: _sendController,
+            handler: send),
+      ],
+    );
+  }
+
+  Future<void> send(String msg) async {
+    String response = await _sendToCurrentFriend(msg);
+    setState(() {
+      _sendController.text = response;
+    });
+  }
+
+  Future<String> _sendToCurrentFriend(String msg) async {
+    return widget.friend!
+        .send(msg)
+        .then((value) => "")
+        .catchError((e) => "Error: $e");
+  }
+}
 
 class Friends extends Iterable<String> {
   Map<String, Friend> _names2Friends = {};
@@ -19,6 +70,8 @@ class Friends extends Iterable<String> {
   String? ipAddr(String? name) => _names2Friends[name]?.ipAddr;
 
   bool hasFriend(String? name) => _names2Friends.containsKey(name);
+
+  Friend? getFriend(String? name) => _names2Friends[name];
 
   String historyFor(String? name) {
     if (hasFriend(name)) {

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -26,18 +26,22 @@ class _ChatScreenState extends State<ChatScreen> {
   @override
   Widget build(BuildContext context) {
     String currentFriend = widget.friend!.name;
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        ScrollText(text: widget.friend!.history()),
-        ActionText(
-            width: 200,
-            label: "Send to $currentFriend",
-            inType: TextInputType.text,
-            controller: _sendController,
-            handler: send),
-      ],
-    );
+    return Scaffold(
+        appBar: AppBar(
+          title: Text("Chat with " + widget.friend!.name),
+        ),
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ScrollText(text: widget.friend!.history()),
+            ActionText(
+                width: 200,
+                label: "Send to $currentFriend",
+                inType: TextInputType.text,
+                controller: _sendController,
+                handler: send),
+          ],
+        ));
   }
 
   Future<void> send(String msg) async {

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -1,64 +1,9 @@
 import 'dart:io';
-import 'package:mutex/mutex.dart';
 import 'package:flutter/material.dart';
-import 'package:text_messenger/text_widgets.dart';
+import 'package:mutex/mutex.dart';
 
 const int ourPort = 8888;
 final m = Mutex();
-
-class ChatScreen extends StatefulWidget {
-  const ChatScreen({super.key, required this.friend});
-
-  final Friend? friend;
-
-  @override
-  State<ChatScreen> createState() => _ChatScreenState();
-}
-
-class _ChatScreenState extends State<ChatScreen> {
-  late TextEditingController _sendController;
-
-  void initState() {
-    super.initState();
-    _sendController = TextEditingController();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    String currentFriend = widget.friend!.name;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Chat with " + widget.friend!.name),
-      ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          ScrollText(text: widget.friend!.history()),
-          ActionText(
-              width: 200,
-              label: "Send to $currentFriend",
-              inType: TextInputType.text,
-              controller: _sendController,
-              handler: send),
-        ],
-      ),
-    );
-  }
-
-  Future<void> send(String msg) async {
-    await widget.friend!.send(msg).then((value) {
-      setState(() {
-        _sendController.text = "";
-      });
-    })
-        // TODO FIX WITH SNACKBAR
-        .catchError((e) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-        content: Text("Error: $e"),
-      ));
-    });
-  }
-}
 
 class Friends extends Iterable<String> {
   Map<String, Friend> _names2Friends = {};
@@ -89,7 +34,7 @@ class Friends extends Iterable<String> {
   Iterator<String> get iterator => _names2Friends.keys.iterator;
 }
 
-class Friend {
+class Friend extends ChangeNotifier {
   final String ipAddr;
   final String name;
   final List<Message> _messages = [];
@@ -108,8 +53,10 @@ class Friend {
   }
 
   Future<void> _add_message(String name, String message) async {
-    await m.protect(
-        () async => _messages.add(Message(author: name, content: message)));
+    await m.protect(() async {
+      _messages.add(Message(author: name, content: message));
+      notifyListeners();
+    });
   }
 
   String history() => _messages

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -27,21 +27,22 @@ class _ChatScreenState extends State<ChatScreen> {
   Widget build(BuildContext context) {
     String currentFriend = widget.friend!.name;
     return Scaffold(
-        appBar: AppBar(
-          title: Text("Chat with " + widget.friend!.name),
-        ),
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            ScrollText(text: widget.friend!.history()),
-            ActionText(
-                width: 200,
-                label: "Send to $currentFriend",
-                inType: TextInputType.text,
-                controller: _sendController,
-                handler: send),
-          ],
-        ));
+      appBar: AppBar(
+        title: Text("Chat with " + widget.friend!.name),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          ScrollText(text: widget.friend!.history()),
+          ActionText(
+              width: 200,
+              label: "Send to $currentFriend",
+              inType: TextInputType.text,
+              controller: _sendController,
+              handler: send),
+        ],
+      ),
+    );
   }
 
   Future<void> send(String msg) async {
@@ -49,9 +50,13 @@ class _ChatScreenState extends State<ChatScreen> {
       setState(() {
         _sendController.text = "";
       });
+    })
+        // TODO FIX WITH SNACKBAR
+        .catchError((e) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text("Error: $e"),
+      ));
     });
-    // TODO FIX WITH SNACKBAR
-    //.catchError((e) => "Error: $e");
   }
 }
 

--- a/lib/list_items.dart
+++ b/lib/list_items.dart
@@ -17,7 +17,8 @@ class FriendListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
+    return Card(
+        child: ListTile(
       onTap: () {
         onListTapped(friend);
       },
@@ -32,6 +33,6 @@ class FriendListItem extends StatelessWidget {
         friend.name,
       ),
       subtitle: Text(friend.ipAddr),
-    );
+    ));
   }
 }

--- a/lib/list_items.dart
+++ b/lib/list_items.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:text_messenger/data.dart';
+
+typedef FriendListChatCallback = Function(Friend item);
+typedef FriendListEditCallback = Function(Friend item);
+
+class FriendListItem extends StatelessWidget {
+  FriendListItem({
+    required this.friend,
+    required this.onListTapped,
+    required this.onListEdited,
+  }) : super(key: ObjectKey(friend));
+
+  final Friend friend;
+  final FriendListChatCallback onListTapped;
+  final FriendListEditCallback onListEdited;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: () {
+        onListTapped(friend);
+      },
+      onLongPress: () {
+        onListEdited(friend);
+      },
+      leading: CircleAvatar(
+        backgroundColor: Theme.of(context).primaryColor,
+        child: Text(friend.name[0]),
+      ),
+      title: Text(
+        friend.name,
+      ),
+      subtitle: Text(friend.ipAddr),
+    );
+  }
+}

--- a/lib/list_items.dart
+++ b/lib/list_items.dart
@@ -26,7 +26,7 @@ class FriendListItem extends StatelessWidget {
       },
       leading: CircleAvatar(
         backgroundColor: Theme.of(context).primaryColor,
-        child: Text(friend.name[0]),
+        child: Text(friend.name[0].toUpperCase()),
       ),
       title: Text(
         friend.name,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -191,10 +191,13 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  void _handleChat(Friend friend) {
-    setState(() {
-      print("Chat");
-    });
+  Future<void> _handleChat(Friend friend) async {
+    print("Chat");
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => ChatScreen(friend: friend),
+      ),
+    );
   }
 
   void _handleEditFriend(Friend friend) {
@@ -205,30 +208,26 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Widget _mainScreen(BuildContext context) {
     _friendList = makeFriendList();
+
     /*return Column(
-      
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         const SizedBox(height: 10.0),
-        Text(_ipaddress!),
-        DropdownButton(
-          value: _currentFriend,
-          items: _friendList,
-          onChanged: updateFriendList,
-        ),
-      ],
-      );
-      */
+        Text(_ipaddress!),*/
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 8.0),
-      children: _friends.map((item) {
+      children: _friends.map((name) {
         return FriendListItem(
-          friend: _friends.getFriend(item)!,
+          friend: _friends.getFriend(name)!,
           onListTapped: _handleChat,
           onListEdited: _handleEditFriend,
         );
       }).toList(),
     );
+    /*
+      ],
+    )*/
+    ;
 
     //return ChatScreen(friend: _friends.getFriend(_currentFriend));
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:text_messenger/data.dart';
 import 'package:text_messenger/text_widgets.dart';
 
+import 'list_items.dart';
+
 void main() {
   runApp(MyApp());
 }
@@ -189,6 +191,18 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
+  void _handleChat(Friend friend) {
+    setState(() {
+      print("Chat");
+    });
+  }
+
+  void _handleEditFriend(Friend friend) {
+    setState(() {
+      print("Edit");
+    });
+  }
+
   Widget _mainScreen(BuildContext context) {
     _friendList = makeFriendList();
     /*return Column(
@@ -203,9 +217,19 @@ class _MyHomePageState extends State<MyHomePage> {
           onChanged: updateFriendList,
         ),
       ],
-      
+      );
+      */
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      children: _friends.map((item) {
+        return FriendListItem(
+          friend: _friends.getFriend(item)!,
+          onListTapped: _handleChat,
+          onListEdited: _handleEditFriend,
+        );
+      }).toList(),
+    );
 
-    );*/
-    return ChatScreen(friend: _friends.getFriend(_currentFriend));
+    //return ChatScreen(friend: _friends.getFriend(_currentFriend));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,7 +40,6 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   String? _ipaddress = "Loading...";
   late Friends _friends;
-  String? _currentFriend;
   late List<DropdownMenuItem<String>> _friendList;
   late TextEditingController _nameController, _ipController;
 
@@ -48,11 +47,8 @@ class _MyHomePageState extends State<MyHomePage> {
     super.initState();
     _friends = Friends();
     _friends.add("Self", "127.0.0.1");
-    _currentFriend = "Self";
-    print("currentFriend: $_currentFriend");
-    _nameController = TextEditingController(text: _currentFriend);
-    _ipController =
-        TextEditingController(text: _friends.ipAddr(_currentFriend));
+    _nameController = TextEditingController();
+    _ipController = TextEditingController();
     _setupServer();
     _findIPAddress();
   }
@@ -88,30 +84,11 @@ class _MyHomePageState extends State<MyHomePage> {
     String received = String.fromCharCodes(incomingData);
     print("Received '$received' from '$ip'");
     _friends.receiveFrom(ip, received);
-    _currentFriend = _friends.getName(ip);
-  }
-
-  // From https://medium.com/@boldijar.paul/comboboxes-in-flutter-cabc9178cc95
-  List<DropdownMenuItem<String>> makeFriendList() {
-    print("making friend list");
-    List<DropdownMenuItem<String>> items = [];
-    for (String friend in _friends) {
-      items.add(DropdownMenuItem(value: friend, child: Text(friend)));
-    }
-    print("${items.length} friends");
-    return items;
-  }
-
-  void updateFriendList(String? selectedFriend) {
-    setState(() {
-      _currentFriend = selectedFriend;
-    });
   }
 
   void addNew() {
     setState(() {
       _friends.add(_nameController.text, _ipController.text);
-      _currentFriend = _nameController.text;
     });
   }
 
@@ -207,8 +184,6 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Widget _mainScreen(BuildContext context) {
-    _friendList = makeFriendList();
-
     /*return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
@@ -228,7 +203,5 @@ class _MyHomePageState extends State<MyHomePage> {
       ],
     )*/
     ;
-
-    //return ChatScreen(friend: _friends.getFriend(_currentFriend));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -149,25 +149,6 @@ class _MyHomePageState extends State<MyHomePage> {
         });
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: _mainScreen(context),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          _displayTextInputDialog(context);
-        },
-        tooltip: 'Add Friend',
-        child: const Icon(Icons.add),
-      ),
-    );
-  }
-
   Future<void> _handleChat(Friend friend) async {
     print("Chat");
     await Navigator.of(context).push(
@@ -183,25 +164,39 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
-  Widget _mainScreen(BuildContext context) {
-    /*return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        const SizedBox(height: 10.0),
-        Text(_ipaddress!),*/
-    return ListView(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      children: _friends.map((name) {
-        return FriendListItem(
-          friend: _friends.getFriend(name)!,
-          onListTapped: _handleChat,
-          onListEdited: _handleEditFriend,
-        );
-      }).toList(),
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: ListView(
+          padding: const EdgeInsets.symmetric(vertical: 8.0),
+          children: _friends.map((name) {
+            return FriendListItem(
+              friend: _friends.getFriend(name)!,
+              onListTapped: _handleChat,
+              onListEdited: _handleEditFriend,
+            );
+          }).toList(),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          _displayTextInputDialog(context);
+        },
+        tooltip: 'Add Friend',
+        child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: Padding(
+          padding: EdgeInsets.all(10),
+          child: Container(
+              width: double.infinity,
+              child: Text(
+                _ipaddress!,
+                textAlign: TextAlign.center,
+              ))),
     );
-    /*
-      ],
-    )*/
-    ;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:text_messenger/data.dart';
 import 'package:text_messenger/text_widgets.dart';
 
+import 'chat.dart';
 import 'list_items.dart';
 
 void main() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,8 +68,9 @@ class _MyHomePageState extends State<MyHomePage> {
           await ServerSocket.bind(InternetAddress.anyIPv4, ourPort);
       server.listen(_listenToSocket); // StreamSubscription<Socket>
     } on SocketException catch (e) {
-      // TODO FIX THIS LATER
-      //_sendController.text = e.message;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text("Error: $e"),
+      ));
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,7 +40,7 @@ class _MyHomePageState extends State<MyHomePage> {
   late Friends _friends;
   String? _currentFriend;
   late List<DropdownMenuItem<String>> _friendList;
-  late TextEditingController _nameController, _ipController, _sendController;
+  late TextEditingController _nameController, _ipController;
 
   void initState() {
     super.initState();
@@ -51,7 +51,6 @@ class _MyHomePageState extends State<MyHomePage> {
     _nameController = TextEditingController(text: _currentFriend);
     _ipController =
         TextEditingController(text: _friends.ipAddr(_currentFriend));
-    _sendController = TextEditingController();
     _setupServer();
     _findIPAddress();
   }
@@ -70,7 +69,8 @@ class _MyHomePageState extends State<MyHomePage> {
           await ServerSocket.bind(InternetAddress.anyIPv4, ourPort);
       server.listen(_listenToSocket); // StreamSubscription<Socket>
     } on SocketException catch (e) {
-      _sendController.text = e.message;
+      // TODO FIX THIS LATER
+      //_sendController.text = e.message;
     }
   }
 
@@ -191,7 +191,8 @@ class _MyHomePageState extends State<MyHomePage> {
 
   Widget _mainScreen(BuildContext context) {
     _friendList = makeFriendList();
-    return Column(
+    /*return Column(
+      
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         const SizedBox(height: 10.0),
@@ -201,32 +202,10 @@ class _MyHomePageState extends State<MyHomePage> {
           items: _friendList,
           onChanged: updateFriendList,
         ),
-        ScrollText(text: _friends.historyFor(_currentFriend)),
-        ActionText(
-            width: 200,
-            label: "Send to $_currentFriend",
-            inType: TextInputType.text,
-            controller: _sendController,
-            handler: send),
       ],
-    );
-  }
+      
 
-  Future<void> send(String msg) async {
-    String response = await _sendToCurrentFriend(msg);
-    setState(() {
-      _sendController.text = response;
-    });
-  }
-
-  Future<String> _sendToCurrentFriend(String msg) async {
-    if (_friends.hasFriend(_currentFriend)) {
-      return _friends
-          .sendTo(_currentFriend, msg)
-          .then((value) => "")
-          .catchError((e) => "Error: $e");
-    } else {
-      return "Can't send to $_currentFriend";
-    }
+    );*/
+    return ChatScreen(friend: _friends.getFriend(_currentFriend));
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: MyHomePage(title: 'Network Demo Home Page'),
+      home: MyHomePage(title: 'Networking Demo'),
     );
   }
 }

--- a/lib/text_widgets.dart
+++ b/lib/text_widgets.dart
@@ -18,14 +18,16 @@ class ActionText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-        width: this.width,
-        child: TextField(
-          controller: controller,
-          keyboardType: inType,
-          onSubmitted: handler,
-          decoration: InputDecoration(labelText: label),
-        ));
+    return Padding(
+        padding: EdgeInsets.all(6.0),
+        child: SizedBox(
+            width: this.width,
+            child: TextField(
+              controller: controller,
+              keyboardType: inType,
+              onSubmitted: handler,
+              decoration: InputDecoration(labelText: label),
+            )));
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
 
   mutex: ^3.0.0
   network_info_plus: ^2.1.4+1
+  provider: ^6.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This took a few steps, but separates out the chat from the friend list, issue #7.

The chat is now on a separate page, which is pushed onto the navigation context. It takes a Friend, and listens to updates from the Friend object about notifications for new messages. All the sending UI and controllers are now on this page.

The friend dropdown is now a friend list, with separate cards for each friend, listing the name and IP. When a card is tapped, it will open the chat for that friend.

Along the way, I also fixed issue #9, so error messages now go to snackbars.

The UI has been revised, putting the user's IP address in the bottomNavigationBar, so it will always be there when scrolling through your many, many friends.